### PR TITLE
Add overview documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Coverage Status](https://coveralls.io/repos/github/timxor/options_market_data/badge.svg?branch=main)](https://coveralls.io/github/timxor/options_market_data?branch=main)
 
 options_market_data
+For a brief overview of the repository structure see [docs/overview.md](docs/overview.md).
+
 
 
 ## Quick Start

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,35 @@
+# Project Overview
+
+This repository collects and processes options market data using a mix of Java and Python.
+Below is a high level description of the available modules and how to get started.
+
+## Directory Summary
+
+- **alpha_vantage_api** – Java code to query the [Alpha Vantage](https://www.alphavantage.co/) API for historical options data.
+- **web-scraper** – Java based web scraper used to download options chains from brokerage sites.
+- **python_examples** – Small Python scripts demonstrating data collection using `yfinance` and other libraries.
+- **charts** – Example charts produced from collected data.
+- **csv_file_examples** – Sample CSV files containing options chain information.
+- **old_quotes** – Archive of older quotes that were previously scraped.
+
+## Quick Start
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/timxor/options_market_data.git
+   cd options_market_data
+   ```
+2. Build and run the Java web scraper:
+   ```bash
+   cd web-scraper
+   mvn clean compile exec:java
+   ```
+3. Run the Python examples (requires Python 3):
+   ```bash
+   cd ../python_examples
+   python -m venv my_env && source my_env/bin/activate
+   pip install -r requirements.txt
+   python yfinance_script.py
+   ```
+
+For detailed instructions see the README files located in each directory.


### PR DESCRIPTION
## Summary
- document project layout in `docs/overview.md`
- link to the overview from the root README

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841f7fa09e88322afc2ec51dcd48a00